### PR TITLE
fix: item variations not required

### DIFF
--- a/lib/src/shared_model/catalog_item.dart
+++ b/lib/src/shared_model/catalog_item.dart
@@ -16,8 +16,8 @@ class CatalogItem extends Equatable {
     this.availableElectronically,
     this.categoryId,
     this.taxIds,
-    required this.modifierListInfo,
-    required this.variations,
+    this.modifierListInfo,
+    this.variations,
     this.productType,
     this.skipModifierScreen,
     this.itemOptions,
@@ -42,7 +42,7 @@ class CatalogItem extends Equatable {
   final String? categoryId;
   final List<String>? taxIds;
   final List<CatalogItemModifierListInfo>? modifierListInfo;
-  final List<CatalogObject> variations;
+  final List<CatalogObject>? variations;
   final CatalogItemProductType? productType;
   final bool? skipModifierScreen;
   final List<CatalogItemOptionForItem>? itemOptions;

--- a/lib/src/shared_model/catalog_item.g.dart
+++ b/lib/src/shared_model/catalog_item.g.dart
@@ -21,8 +21,8 @@ CatalogItem _$CatalogItemFromJson(Map<String, dynamic> json) => CatalogItem(
           ?.map((e) =>
               CatalogItemModifierListInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
-      variations: (json['variations'] as List<dynamic>)
-          .map((e) => CatalogObject.fromJson(e as Map<String, dynamic>))
+      variations: (json['variations'] as List<dynamic>?)
+          ?.map((e) => CatalogObject.fromJson(e as Map<String, dynamic>))
           .toList(),
       productType: _$enumDecodeNullable(
           _$CatalogItemProductTypeEnumMap, json['product_type']),
@@ -50,7 +50,7 @@ Map<String, dynamic> _$CatalogItemToJson(CatalogItem instance) =>
       'tax_ids': instance.taxIds,
       'modifier_list_info':
           instance.modifierListInfo?.map((e) => e.toJson()).toList(),
-      'variations': instance.variations.map((e) => e.toJson()).toList(),
+      'variations': instance.variations?.map((e) => e.toJson()).toList(),
       'product_type': _$CatalogItemProductTypeEnumMap[instance.productType],
       'skip_modifier_screen': instance.skipModifierScreen,
       'item_options': instance.itemOptions?.map((e) => e.toJson()).toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_connect
 description: A wrapper for the Square Connect APIs. It's intended use is in a flutter application to manage inventory, catalog, customers, labor, and more on the Square platform.
-version: 2.0.0-dev.49
+version: 2.0.0-dev.50
 homepage: https://github.com/mtwichel/square-connect-flutter-library
 
 environment:


### PR DESCRIPTION
there is nothing that I can see that requires a CatagoryItem to have a variation: https://developer.squareup.com/reference/square/objects/CatalogItem
Even though in practice an item is required to have to a variation, when it is deleted, the list of variations seem to come back null.